### PR TITLE
Bug/fix comment before first feature line

### DIFF
--- a/app/pr-review.hs
+++ b/app/pr-review.hs
@@ -122,7 +122,7 @@ extractComments original edited =
       (cmts, al, current) = foldl' (\(cs, al, cur) d ->
         case d of
           Both ls _ ->
-            let newCs = if null cur then cs else cs ++ [(if al - 1 == 0 then 1 else al - 1, intercalate "\n" cur)]
+            let newCs = if null cur then cs else cs ++ [(if al == 0 then 1 else al, intercalate "\n" cur)]
             in (newCs, al + length ls, [])
           First ls ->
             (cs, al + length ls, cur)

--- a/src/PRTools/CommentRenderer.hs
+++ b/src/PRTools/CommentRenderer.hs
@@ -113,11 +113,13 @@ renderForFix branch file cmts = do
     return c { cmLine = newLine }
     ) cmts
   let sortedCmts = sortBy (comparing cmLine) adjustedCmts
-  let (augmentedLines, _) = foldl' (\(acc, offset) c ->
-                                      let insert_pos = cmLine c + offset
-                                          before = take insert_pos acc
-                                          after = drop insert_pos acc
-                                          marker = "-- REVIEW COMMENT [" ++ cmId c ++ "]: " ++ cmText c ++ " [status:" ++ cmStatus c ++ "] [answer:" ++ fromMaybe "" (cmAnswer c) ++ "]"
-                                      in (before ++ [marker] ++ after, offset + 1)
-                                   ) (fileLines, 0) sortedCmts
+  let (augmentedLines, _) = foldl' insertComment (fileLines, 0) sortedCmts
   return $ unlines augmentedLines
+  where
+    insertComment :: ([String], Int) -> Cmt -> ([String], Int)
+    insertComment (acc, offset) c =
+      let insert_pos = cmLine c + offset
+          before = take insert_pos acc
+          after = drop insert_pos acc
+          marker = "-- REVIEW COMMENT [" ++ cmId c ++ "]: " ++ cmText c ++ " [status:" ++ cmStatus c ++ "] [answer:" ++ fromMaybe "" (cmAnswer c) ++ "]"
+      in (before ++ [marker] ++ after, offset + 1)

--- a/src/PRTools/CommentRenderer.hs
+++ b/src/PRTools/CommentRenderer.hs
@@ -91,7 +91,7 @@ renderForReview baseB branch file cmts = do
               Just l ->
                 let (inserted, remaining) = span (\c -> cmLine c == l) rem_cmts
                     markers = map (\c -> "-- COMMENT [" ++ cmId c ++ "]: " ++ trimTrailingNewlines (cmText c)) inserted
-                    to_add = markers ++ [line]
+                    to_add = line : markers
                     new_rev = foldl' (flip (:)) rev_acc (reverse to_add)
                 in (new_rev, remaining)
           (final_rev, final_rem) = foldl' go ([], scmts) clines
@@ -118,7 +118,8 @@ renderForFix branch file cmts = do
   where
     insertComment :: ([String], Int) -> Cmt -> ([String], Int)
     insertComment (acc, offset) c =
-      let insert_pos = cmLine c + offset
+      let insert_pos' = cmLine c + offset - 1
+          insert_pos = max 0 insert_pos'
           before = take insert_pos acc
           after = drop insert_pos acc
           marker = "-- REVIEW COMMENT [" ++ cmId c ++ "]: " ++ cmText c ++ " [status:" ++ cmStatus c ++ "] [answer:" ++ fromMaybe "" (cmAnswer c) ++ "]"


### PR DESCRIPTION
Fix association of comments to line-numbers. The comment line number should be the line number from the code immediately following the comment. This fixes how comments are displayed when the comment is the first in a FEATURE section on pr-preview open.