### PR TITLE
Common comments logic

### DIFF
--- a/app/pr-fix.hs
+++ b/app/pr-fix.hs
@@ -251,20 +251,7 @@ main = do
     FComments withCtx -> do
       mState <- loadReviewState fixFile
       case mState of
-        Just state | rsStatus state == "fixing" -> do
-          let comments = rsComments state
-          let branch = rsBranch state
-          if withCtx then
-            mapM_ (\c -> do
-              content <- readProcess "git" ["show", branch ++ ":" ++ cmFile c] ""
-              let fileLines = lines content
-              let start = max 0 (cmLine c - 4)
-              let context = take 7 (drop start fileLines)
-              let numberedContext = zipWith (\i ln -> "  " ++ show (start + 1 + i) ++ ": " ++ ln) [0..] context
-              putStrLn $ "File: " ++ cmFile c ++ "\nLine: " ++ show (cmLine c) ++ "\nID: " ++ cmId c ++ "\nStatus: " ++ cmStatus c ++ "\nComment: " ++ cmText c ++ "\nAnswer: " ++ fromMaybe "" (cmAnswer c) ++ "\nContext:\n" ++ unlines numberedContext ++ "\n---"
-              ) comments
-            else
-            mapM_ (\c -> putStrLn $ cmFile c ++ ":" ++ show (cmLine c) ++ " [" ++ cmId c ++ "] - " ++ map (\ch -> if ch == '\n' then ' ' else ch) (cmText c) ++ " [" ++ cmStatus c ++ "]" ++ maybe "" (\a -> " answer: " ++ map (\ch -> if ch == '\n' then ' ' else ch) a) (cmAnswer c)) comments
+        Just state | rsStatus state == "fixing" -> displayComments (rsBranch state) (rsComments state) withCtx
         _ -> hPutStrLn stderr "No active fix session"
     FFiles -> do
       mState <- loadReviewState fixFile

--- a/app/pr-review.hs
+++ b/app/pr-review.hs
@@ -201,7 +201,7 @@ main = do
           hPutStrLn stderr "No review"
           exitFailure
         Just state -> do
-          let updatedComments = map (\c -> if cmId c == rid then c { cmResolved = True } else c) (rsComments state)
+          let updatedComments = map (\c -> if cmId c == rid then c { cmResolved = True, cmStatus = "solved" } else c) (rsComments state)
           if updatedComments == rsComments state
             then putStrLn "Comment not found"
             else do
@@ -261,19 +261,7 @@ main = do
         Nothing -> do
           hPutStrLn stderr "No review"
           exitFailure
-        Just state -> do
-          let comments = rsComments state
-          if withCtx then
-            mapM_ (\c -> do
-              content <- readProcess "git" ["show", branch ++ ":" ++ cmFile c] ""
-              let fileLines = lines content
-              let start = max 0 (cmLine c - 4)
-              let context = take 7 (drop start fileLines)
-              let numberedContext = zipWith (\i ln -> "  " ++ show (start + 1 + i) ++ ": " ++ ln) [0..] context
-              putStrLn $ "File: " ++ cmFile c ++ "\nLine: " ++ show (cmLine c) ++ "\nID: " ++ cmId c ++ "\nStatus: " ++ (if cmResolved c then "resolved" else "unresolved") ++ "\nComment: " ++ cmText c ++ "\nContext:\n" ++ unlines numberedContext ++ "\n---"
-              ) comments
-            else
-            mapM_ (\c -> putStrLn $ cmFile c ++ ":" ++ show (cmLine c) ++ " [" ++ cmId c ++ "] - " ++ map (\ch -> if ch == '\n' then ' ' else ch) (cmText c) ++ " [" ++ (if cmResolved c then "resolved" else "unresolved") ++ "]") comments
+        Just state -> displayComments branch (rsComments state) withCtx
 
 handleNav :: NavAction -> FilePath -> String -> String -> IO ()
 handleNav action rf branch baseB = do


### PR DESCRIPTION
pr-fix comments and pr-review comments should use the same logic for displaying the comments.

This PR extracts the logic into the library and the 2 apps just call the logic from the library.