### PR TITLE
Feature/pr track auto status

### DIFF
--- a/app/pr-fix.hs
+++ b/app/pr-fix.hs
@@ -260,7 +260,7 @@ main = do
         let state = ReviewState "fixing" 0 uniqueFiles updatedCmts branch fixer
         saveReviewState fixFile state
         putStrLn "Fix session started"
-        recordPR branch
+        recordPR branch >>= putStrLn
     FComments withCtx -> do
       mState <- loadReviewState fixFile
       case mState of

--- a/app/pr-review.hs
+++ b/app/pr-review.hs
@@ -156,14 +156,14 @@ main = do
           let resumed = existing { rsStatus = "active", rsFiles = files, rsCurrentIndex = 0 }
           saveReviewState reviewFile resumed
           putStrLn "Resuming existing review"
-          recordPR branch
+          recordPR branch >>= putStrLn
         Nothing -> do
           filesOut <- readProcess "git" ["diff", "--name-only", baseB, "--"] ""
           let files = lines filesOut
           let newState = ReviewState "active" 0 files [] branch reviewer
           saveReviewState reviewFile newState
           putStrLn "New review started"
-          recordPR branch
+          recordPR branch >>= putStrLn
     Next -> handleNav NavNext reviewFile branch baseB
     Previous -> handleNav NavPrevious reviewFile branch baseB
     Open -> handleNav NavOpen reviewFile branch baseB

--- a/app/pr-snapshot.hs
+++ b/app/pr-snapshot.hs
@@ -69,4 +69,4 @@ main = do
       let editor = maybe "vi" id editorM
       callProcess editor [outputPath]
   putStrLn $ "Snapshot written to " ++ outputPath
-  recordPR branch
+  recordPR branch >>= putStrLn

--- a/app/pr-track.hs
+++ b/app/pr-track.hs
@@ -80,14 +80,9 @@ main = do
       branch <- case mbBranch of
         Just b -> return b
         Nothing -> fmap trimTrailing (readProcess "git" ["rev-parse", "--abbrev-ref", "HEAD"] "")
-      recordPR branch
-      putStrLn $ "Recorded snapshot for " ++ branch
+      msg <- recordPR branch
+      putStrLn $ "Recorded snapshot for " ++ branch ++ (if null msg then "" else ". " ++ msg)
     List -> do
       if Map.null state
         then putStrLn "No PRs tracked"
         else Map.foldrWithKey (\b pr acc -> putStrLn (b ++ ": " ++ prStatus pr ++ " (approvals: " ++ show (length $ prApprovals pr) ++ ")") >> acc) (return ()) state
-
-isAncestor :: String -> String -> IO Bool
-isAncestor commit branch = do
-  (code, _, _) <- readProcessWithExitCode "git" ["merge-base", "--is-ancestor", commit, branch] ""
-  return (code == ExitSuccess)


### PR DESCRIPTION
Use pr-update to update the status of a tracked PR to merged or stale.

Handle the case when the branch does not longer exists, looking only
at the state of commits.