### PR TITLE
fix: use merge base for diffs

### DIFF
--- a/app/pr-snapshot.hs
+++ b/app/pr-snapshot.hs
@@ -29,10 +29,11 @@ main = do
   branch <- case optBranch opts of
     Just b -> return b
     Nothing -> fmap trimTrailing (readProcess "git" ["rev-parse", "--abbrev-ref", "HEAD"] "")
+  mergeBase <- trimTrailing <$> readProcess "git" ["merge-base", baseB, branch] ""
   author <- fmap trimTrailing (readProcess "git" ["config", "user.name"] "")
   commitsOut <- readProcess "git" ["log", "--format=%h %s", baseB ++ ".." ++ branch, "--"] ""
   let commitList = unlines $ map ("- " ++) $ lines commitsOut
-  diffSummary <- readProcess "git" ["diff", "--stat", baseB, branch, "--"] ""
+  diffSummary <- readProcess "git" ["diff", "--stat", mergeBase, branch, "--"] ""
   let descLines = case optMessage opts of
         Just msg -> lines msg
         Nothing -> ["(Enter your PR description here)"]

--- a/src/PRTools/CommentRenderer.hs
+++ b/src/PRTools/CommentRenderer.hs
@@ -43,8 +43,8 @@ remapLine revision file branch target = do
 
 -- Render for review: conflict style with comments inserted
 renderForReview :: String -> String -> String -> [Cmt] -> IO String
-renderForReview baseB branch file cmts = do
-  baseContent <- catch (readProcess "git" ["show", baseB ++ ":" ++ file] "")
+renderForReview mergeBase branch file cmts = do
+  baseContent <- catch (readProcess "git" ["show", mergeBase ++ ":" ++ file] "")
                        (\(_ :: IOException) -> return "")
   featureContent <- catch (readProcess "git" ["show", branch ++ ":" ++ file] "")
                           (\e -> do hPutStrLn stderr $ "Warning: " ++ show (e :: IOException); return "")


### PR DESCRIPTION
Compute a merde base for computing diffs - a commit that is
both in the base branch and in the PR branch.