### PR TITLE
fix: Add comment filtering flags to pr-review and pr-fix comments

### DIFF
--- a/pr-tools.cabal
+++ b/pr-tools.cabal
@@ -24,6 +24,7 @@ library
                   , yaml
                   , Diff
                   , time
+                  , extra
   hs-source-dirs:   src
 
 executable pr-snapshot

--- a/src/PRTools/CommentRenderer.hs
+++ b/src/PRTools/CommentRenderer.hs
@@ -7,6 +7,7 @@ module PRTools.CommentRenderer where
 import Control.Exception (catch, IOException)
 import Data.Algorithm.Diff (PolyDiff(..), getGroupedDiff)
 import Data.List (foldl', sortBy)
+import Data.List.Extra (trim)
 import System.IO (hPutStrLn, stderr)
 import System.Process (readProcess)
 import PRTools.ReviewState (Cmt(..))
@@ -134,7 +135,8 @@ displayComments branch cmts withCtx = do
       let start = max 0 (cmLine c - 4)
       let context = take 7 (drop start fileLines)
       let numberedContext = zipWith (\i ln -> "  " ++ show (start + 1 + i) ++ ": " ++ ln) [0..] context
-      putStrLn $ "File: " ++ cmFile c ++ "\nLine: " ++ show (cmLine c) ++ "\nID: " ++ cmId c ++ "\nStatus: " ++ cmStatus c ++ "\nComment: " ++ cmText c ++ "\nAnswer: " ++ fromMaybe "" (cmAnswer c) ++ "\nContext:\n" ++ unlines numberedContext ++ "\n---"
+      putStrLn $ "File: " ++ cmFile c ++ "\nLine: " ++ show (cmLine c) ++ "\nID: " ++ cmId c ++ "\nResolved: " ++ show (cmResolved c) ++ "\nStatus: " ++ cmStatus c ++ "\nComment: " ++ trim (cmText c) ++ "\nAnswer: " ++ trim (fromMaybe "" (cmAnswer c)) ++ "\nContext:\n" ++ unlines numberedContext ++ "\n---"
       ) cmts
     else
-    mapM_ (\c -> putStrLn $ cmFile c ++ ":" ++ show (cmLine c) ++ " [" ++ cmId c ++ "] - " ++ map (\ch -> if ch == '\n' then ' ' else ch) (cmText c) ++ " [" ++ cmStatus c ++ "]" ++ maybe "" (\a -> " answer: " ++ map (\ch -> if ch == '\n' then ' ' else ch) a) (cmAnswer c)) cmts
+    mapM_ (\c -> putStrLn $ cmFile c ++ ":" ++ show (cmLine c) ++ " [" ++ cmId c ++ "][" ++ (if cmResolved c then "Resolved" else "") ++ "]\n\t" ++ trim (map (\ch -> if ch == '\n' then ' ' else ch) (cmText c)) ++ " [" ++ cmStatus c ++ "]" ++ maybe "" (\a -> " answer: " ++ trim (map (\ch -> if ch == '\n' then ' ' else ch) a)) (cmAnswer c) ++ "\n") cmts
+


### PR DESCRIPTION
This commit introduces three new flags for `comments` commands in both `pr-review` and `pr-fix`:
- Default to showing unresolved comments
- Add `--all` to show all comments
- Add `--resolved` to show only resolved comments

It also add a few improvements on readability of the displayed comments:
- feat: Add helper flag to display command-specific help for comments
- Displaying Resolved/Unresolved for comments.
- Trim spaces from comments and answers when displaying.
- Improve readability when displaying comments in compact form, by adding some newlines and tabs.