### PR TITLE
feat: Implement Slack file attachment for PR tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ pr-fix send
 
 ### pr-init
 
-Interactively generate or update configuration file (.pr-tools.yaml) for pr-tools, including base-branch and optional slack-webhook. Also updates .gitignore with recommended entries.
+Interactively generate or update configuration file (.pr-tools.yaml) for pr-tools, prompting for base-branch, optional slack-webhook, slack-token, slack-channel, and stale-days (with current values as defaults if updating). Also updates .gitignore with recommended entries.
 
 ```
 pr-init

--- a/README.md
+++ b/README.md
@@ -48,20 +48,52 @@ Update the source tree and reinstall:
 ## Configuration
 
 
-### Slack Integration
+## Slack Configurations
 
-For `pr-send` and `pr-merge` to post notifications to Slack, add the `slack-webhook` to your `.pr-tools.yaml` file.
+PR Tools supports two Slack integration methods: Incoming Webhooks for simple text messages and Slack API Tokens for advanced features like file attachments. Webhooks are easier to set up and sufficient for basic notifications, while API Tokens enable uploading detailed content as files, improving readability for long messages (e.g., reviews or snapshots). If both are configured, the tool prioritizes API Tokens for commands that benefit from attachments; otherwise, it falls back to webhooks.
 
-- Generate a webhook URL in your Slack workspace: Go to [Slack Apps](https://api.slack.com/apps), create an app, and enable Incoming Webhooks.
+### Webhook Configuration
 
-If not set, `pr-send` will fail with an error, and `pr-merge` will skip the notification.
+Webhooks allow posting plain text messages to a Slack channel. This is ideal for short notifications but may truncate or clutter long content.
 
-### Base Branch and Slack Webhook
+To obtain a webhook:
+1. Go to [Slack Apps](https://api.slack.com/apps) and create a new app.
+2. Enable "Incoming Webhooks" under "Add features & functionality".
+3. Activate webhooks and add one to a channel, copying the generated URL (starts with `https://hooks.slack.com/services/`).
+
+Add to your `.pr-tools.yaml`:
+```yaml
+slack-webhook: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+```
+
+If not set, commands like `pr-send` will fail, and others (e.g., `pr-merge`) will skip notifications.
+
+### Slack API Token Configuration
+
+API Tokens enable file attachments, allowing detailed messages (e.g., from `pr-review send`, `pr-fix send`, `pr-send`) to be uploaded as .md files with a short summary message. This requires a bot token with `files:write` scope.
+
+To obtain a token:
+1. Go to [Slack Apps](https://api.slack.com/apps) and create a new app.
+2. Under "Add features & functionality", select "Bots" and create a bot user.
+3. Under "OAuth & Permissions", add the `files:write` scope (and optionally `chat:write` for messages).
+4. Install the app to your workspace, granting permissions.
+5. Copy the "Bot User OAuth Token" (starts with `xoxb-`).
+6. Find the channel ID: In Slack, right-click the channel, select "View channel details", and copy the ID (starts with `C` or `G`).
+
+Add to your `.pr-tools.yaml`:
+```yaml
+slack-token: "xoxb-your-bot-token"
+slack-channel: "C0123456789"  # Channel ID
+```
+
+### Base Branch and Slack Configuration
 
 Use `pr-init` or manually create a `.pr-tools.yaml` file in the project root with:
 ```yaml
 base-branch: main  # or your default base branch
-slack-webhook: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"  # optional Slack webhook URL
+slack-webhook: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"  # optional
+slack-token: "xoxb-your-bot-token"  # optional for attachments
+slack-channel: "C0123456789"  # required if using token
 ```
 
 ### Recommended .gitignore Entries

--- a/app/pr-review.hs
+++ b/app/pr-review.hs
@@ -301,7 +301,12 @@ main = do
                                         "File: " ++ cmFile c ++ "\nLine: " ++ show (cmLine c) ++ "\nID: " ++ cmId c ++ "\nStatus: " ++ cmStatus c ++ "\nResolved: " ++ show (cmResolved c) ++ "\nRevision: " ++ cmRevision c ++ "\nComment: " ++ cmText c ++ "\nAnswer: " ++ fromMaybe "" (cmAnswer c) ++ "\n---\n"
                                     ) comments
           let fullContent = concat commentTexts
-          let summary = "Review for " ++ branch ++ " by " ++ reviewer ++ " attached."
+          let total = length comments
+          let solved = length (filter cmResolved comments)
+          let unsolved = total - solved
+          let summary = if total == 0 || solved == total
+                        then "Review for " ++ branch ++ " by " ++ reviewer ++ ": Everything is solved! 🎉"
+                        else "Review for " ++ branch ++ " by " ++ reviewer ++ " attached. Total comments: " ++ show total ++ ", Solved: " ++ show solved ++ ", To solve: " ++ show unsolved ++ "."
           let filename = "review-summary-" ++ sanitizeBranch branch ++ "-" ++ reviewer ++ ".md"
           mbToken <- getSlackToken
           mbChannel <- getSlackChannel
@@ -313,7 +318,7 @@ main = do
                 hPutStrLn stderr "Slack not configured"
                 exitFailure
               Just webhook -> do
-                let message = "Review for " ++ branch ++ " by " ++ reviewer ++ ":\n" ++ fullContent
+                let message = summary ++ "\n" ++ fullContent
                 sendViaWebhook webhook message
     Comments withCtx showAll showResolved -> do
       mState <- loadReviewState reviewFile

--- a/app/pr-send.hs
+++ b/app/pr-send.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-import PRTools.Config (trimTrailing, sanitizeBranch, getSlackWebhook)
+import PRTools.Config (trimTrailing, sanitizeBranch, getSlackWebhook, getSlackToken, getSlackChannel)
 
 import Data.Aeson (encode, object, (.=))
 import qualified Data.ByteString as BS
@@ -15,36 +15,34 @@ import System.Exit (exitWith, ExitCode(..))
 import System.FilePath ((</>))
 import System.IO (hPutStrLn, stderr)
 import System.Process (readProcess)
+import PRTools.Slack (sendViaApi, sendViaWebhook)
 
 main :: IO ()
 main = do
-  mbWebhook <- getSlackWebhook
-  case mbWebhook of
-    Nothing -> do
-      hPutStrLn stderr "Error: slack-webhook not set in .pr-tools.yaml"
+  args <- getArgs
+  branch <- if not (null args) then return (head args) else fmap trimTrailing (readProcess "git" ["rev-parse", "--abbrev-ref", "HEAD"] "")
+  root <- fmap trimTrailing (readProcess "git" ["rev-parse", "--show-toplevel"] "")
+  let safeBranch = sanitizeBranch branch
+  let mdPath = root </> ".pr-drafts" </> (safeBranch ++ ".md")
+  exists <- doesFileExist mdPath
+  if not exists
+    then do
+      hPutStrLn stderr $ "Error: Snapshot not found at " ++ mdPath
       exitWith (ExitFailure 1)
-    Just webhook -> do
-      args <- getArgs
-      branch <- if not (null args) then return (head args) else fmap trimTrailing (readProcess "git" ["rev-parse", "--abbrev-ref", "HEAD"] "")
-      root <- fmap trimTrailing (readProcess "git" ["rev-parse", "--show-toplevel"] "")
-      let safeBranch = sanitizeBranch branch
-      let mdPath = root </> ".pr-drafts" </> (safeBranch ++ ".md")
-      exists <- doesFileExist mdPath
-      if not exists
-        then do
-          hPutStrLn stderr $ "Error: Snapshot not found at " ++ mdPath
-          exitWith (ExitFailure 1)
-        else do
-          md <- readFile mdPath
-          let message = "New PR: " ++ branch ++ "\n\n" ++ md ++ "\n\nReact with :thumbsup: to approve or :thumbsdown: to request changes."
-          manager <- newManager tlsManagerSettings
-          initReq <- parseRequest webhook
-          let req = initReq
-                { method = "POST"
-                , requestBody = RequestBodyLBS $ encode $ object ["text" .= message]
-                , requestHeaders = [(mk "Content-Type", "application/json")]
-                }
-          response <- httpLbs req manager
-          if statusCode (responseStatus response) == 200
-            then putStrLn "PR sent to Slack"
-            else putStrLn "Error posting to Slack"
+    else do
+      md <- readFile mdPath
+      let summary = "New PR: " ++ branch ++ ". See attached for details.\n\nReact with :thumbsup: to approve or :thumbsdown: to request changes."
+      let fileContent = md
+      let filename = "pr-snapshot-" ++ safeBranch ++ ".md"
+      mbToken <- getSlackToken
+      mbChannel <- getSlackChannel
+      mbWebhook <- getSlackWebhook
+      case (mbToken, mbChannel) of
+        (Just token, Just channel) -> sendViaApi summary fileContent filename channel token
+        _ -> case mbWebhook of
+          Nothing -> do
+            hPutStrLn stderr "Slack not configured"
+            exitWith (ExitFailure 1)
+          Just webhook -> do
+            let message = "New PR: " ++ branch ++ "\n\n" ++ md ++ "\n\nReact with :thumbsup: to approve or :thumbsdown: to request changes."
+            sendViaWebhook webhook message

--- a/pr-tools.cabal
+++ b/pr-tools.cabal
@@ -17,6 +17,7 @@ library
                   , PRTools.PRState
                   , PRTools.ReviewState
                   , PRTools.CommentRenderer
+                  , PRTools.Slack
   build-depends:    aeson
                   , containers
                   , directory
@@ -25,6 +26,13 @@ library
                   , Diff
                   , time
                   , extra
+                  , uuid
+                  , bytestring
+                  , http-client
+                  , http-client-tls
+                  , http-types
+                  , text
+                  , case-insensitive
   hs-source-dirs:   src
 
 executable pr-snapshot

--- a/src/PRTools/Config.hs
+++ b/src/PRTools/Config.hs
@@ -10,10 +10,10 @@ import Data.Yaml (FromJSON(..), ParseException, decodeFileEither, parseJSON, wit
 import System.Directory (doesFileExist)
 import System.Process (readProcess)
 
-data Config = Config { cfgBaseBranch :: String, cfgSlackWebhook :: Maybe String, cfgStaleDays :: Maybe Int } deriving Show
+data Config = Config { cfgBaseBranch :: String, cfgSlackWebhook :: Maybe String, cfgStaleDays :: Maybe Int, cfgSlackToken :: Maybe String, cfgSlackChannel :: Maybe String } deriving Show
 
 instance FromJSON Config where
-  parseJSON = withObject "Config" $ \v -> Config <$> v .: "base-branch" <*> v .:? "slack-webhook" <*> v .:? "stale-days"
+  parseJSON = withObject "Config" $ \v -> Config <$> v .: "base-branch" <*> v .:? "slack-webhook" <*> v .:? "stale-days" <*> v .:? "slack-token" <*> v .:? "slack-channel"
 
 getBaseBranch :: IO String
 getBaseBranch = do
@@ -36,6 +36,30 @@ getSlackWebhook = do
       res <- decodeFileEither configPath
       case res of
         Right config -> return $ cfgSlackWebhook config
+        Left _ -> return Nothing
+    else return Nothing
+
+getSlackToken :: IO (Maybe String)
+getSlackToken = do
+  let configPath = ".pr-tools.yaml"
+  exists <- doesFileExist configPath
+  if exists
+    then do
+      res <- decodeFileEither configPath
+      case res of
+        Right config -> return $ cfgSlackToken config
+        Left _ -> return Nothing
+    else return Nothing
+
+getSlackChannel :: IO (Maybe String)
+getSlackChannel = do
+  let configPath = ".pr-tools.yaml"
+  exists <- doesFileExist configPath
+  if exists
+    then do
+      res <- decodeFileEither configPath
+      case res of
+        Right config -> return $ cfgSlackChannel config
         Left _ -> return Nothing
     else return Nothing
 

--- a/src/PRTools/Slack.hs
+++ b/src/PRTools/Slack.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module PRTools.Slack where
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Aeson (Value(..), encode, object, (.=), decode)
+import qualified Data.Aeson.KeyMap as KM
+import Network.HTTP.Client (RequestBody(RequestBodyLBS), httpLbs, method, newManager, parseRequest, requestBody, requestHeaders, responseBody, responseStatus, urlEncodedBody)
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types (statusCode)
+import System.IO (hPutStrLn, stderr)
+import Data.UUID.V4 (nextRandom)
+import Data.UUID (toString)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.CaseInsensitive (mk)
+import Data.Maybe (fromMaybe)
+import qualified Data.ByteString.Char8 as BSC
+
+sendViaWebhook :: String -> String -> IO ()
+sendViaWebhook webhook message = do
+  manager <- newManager tlsManagerSettings
+  initReq <- parseRequest webhook
+  let req = initReq
+        { method = "POST"
+        , requestBody = RequestBodyLBS $ encode $ object ["text" .= message]
+        , requestHeaders = [(mk (TE.encodeUtf8 (T.pack "Content-Type")), TE.encodeUtf8 (T.pack "application/json"))]
+        }
+  response <- httpLbs req manager
+  if statusCode (responseStatus response) == 200
+    then putStrLn "Sent to Slack"
+    else hPutStrLn stderr "Error sending to Slack"
+
+sendViaApi :: String -> String -> String -> String -> String -> IO ()
+sendViaApi summary fileContent filename channel token = do
+  manager <- newManager tlsManagerSettings
+
+  -- Step 1: Get upload URL
+  initUrlReq <- parseRequest "https://slack.com/api/files.getUploadURLExternal"
+  let pairs = [ ("filename", BSC.pack filename)
+              , ("length", BSC.pack $ show $ BS.length (TE.encodeUtf8 (T.pack fileContent)))
+              ]
+  let urlReq = urlEncodedBody pairs initUrlReq
+        { method = "POST"
+        , requestHeaders =
+          [ (mk "Authorization", TE.encodeUtf8 (T.pack ("Bearer " ++ token)))
+          ]
+        }
+  urlResp <- httpLbs urlReq manager
+  let urlStatus = statusCode (responseStatus urlResp)
+  if urlStatus /= 200
+    then hPutStrLn stderr $ "HTTP error getting upload URL: " ++ show urlStatus
+    else case decode (responseBody urlResp) of
+      Just (Object val) -> case (KM.lookup "ok" val, KM.lookup "upload_url" val, KM.lookup "file_id" val) of
+        (Just (Bool True), Just (String url), Just (String fileId)) -> do
+          -- Step 2: Upload file to URL
+          initUploadReq <- parseRequest (T.unpack url)
+          let uploadReq = initUploadReq
+                { method = "POST"
+                , requestBody = RequestBodyLBS (LBS.fromStrict (TE.encodeUtf8 (T.pack fileContent)))
+                , requestHeaders = [(mk "Content-Type", "application/octet-stream")]
+                }
+          uploadResp <- httpLbs uploadReq manager
+          let uploadStatus = statusCode (responseStatus uploadResp)
+          if uploadStatus /= 200
+            then hPutStrLn stderr $ "HTTP error uploading file: " ++ show uploadStatus
+            else do
+              -- Step 3: Complete upload
+              initCompleteReq <- parseRequest "https://slack.com/api/files.completeUploadExternal"
+              let completeReq = initCompleteReq
+                    { method = "POST"
+                    , requestBody = RequestBodyLBS $ encode $ object
+                      [ "files" .= [object ["id" .= fileId, "title" .= filename]]
+                      , "channel_id" .= channel
+                      , "initial_comment" .= summary
+                      ]
+                    , requestHeaders =
+                      [ (mk "Authorization", TE.encodeUtf8 (T.pack ("Bearer " ++ token)))
+                      , (mk "Content-Type", "application/json")
+                      ]
+                    }
+              completeResp <- httpLbs completeReq manager
+              let completeStatus = statusCode (responseStatus completeResp)
+              if completeStatus /= 200
+                then hPutStrLn stderr $ "HTTP error completing upload: " ++ show completeStatus
+                else case decode (responseBody completeResp) of
+                  Just (Object cVal) -> case KM.lookup "ok" cVal of
+                    Just (Bool True) -> putStrLn "Sent to Slack as attachment"
+                    _ -> do
+                      let errMsg = fromMaybe "Unknown error" (KM.lookup "error" cVal >>= \v -> case v of {String s -> Just (T.unpack s); _ -> Nothing})
+                      hPutStrLn stderr $ "Slack API error: " ++ errMsg
+                  _ -> hPutStrLn stderr "Failed to parse complete response"
+        _ -> do
+          let errMsg = fromMaybe "Unknown error" (KM.lookup "error" val >>= \v -> case v of {String s -> Just (T.unpack s); _ -> Nothing})
+          hPutStrLn stderr $ "Slack API error getting URL: " ++ errMsg
+      _ -> hPutStrLn stderr "Failed to parse URL response"


### PR DESCRIPTION
    Add support for sending Slack messages with file attachments across pr-review, pr-fix, and pr-send commands. Key changes include:
    
    - Add new configuration options for Slack token and channel
    - Create PRTools.Slack module for handling Slack API and webhook sends
    - Update send commands to use file attachments when token/channel are configured
    - Add uuid dependency for generating unique multipart form boundaries
    
    The implementation allows more detailed messages to be sent as file attachments, improving readability and reducing Slack message clutter.