### PR TITLE
fix(parser): Correctly parse pr-fix answer

### DIFF
--- a/app/pr-fix.hs
+++ b/app/pr-fix.hs
@@ -26,7 +26,7 @@ import PRTools.CommentRenderer
 import PRTools.CommentFormatter
 import PRTools.PRState (recordPR)
 import PRTools.Slack (sendViaApi, sendViaWebhook)
-
+import PRTools.FixParser
 import Control.Monad (unless)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (isJust)
@@ -146,39 +146,6 @@ parseEditedFix lines cmts = go lines [] cmts
               afterRest = drop skipEnd rest
           in go afterRest accLines updated  -- Skip block, continue with rest
       | otherwise = go lns (ln : accLines) accCmts
-
-    parseBlock :: [String] -> [Cmt] -> [Cmt]  -- Returns only updated cmts
-    parseBlock (header:body) accCmts =
-      let cidStart = length ("-- REVIEW COMMENT BEGIN [" :: String)
-          cidEnd = findIndex (== ']') (drop cidStart header)  -- Safer than maybe
-          cid = case cidEnd of
-                  Just end -> take 8 (drop cidStart header)
-                  Nothing -> ""
-          afterCid = maybe "" (\end -> drop (cidStart + end + 1) header) cidEnd  -- +1 for ]
-          statusStart = findSub "[status:" afterCid
-          afterStatusLabel = maybe afterCid (\start -> drop (start + 8) afterCid) statusStart
-          statusEnd = findSub "]" afterStatusLabel
-          status = maybe "not-solved" (\end -> take end afterStatusLabel) statusEnd
-          afterStatus = maybe afterStatusLabel (\end -> drop (end + 1) afterStatusLabel) statusEnd
-          answerStart = findSub "[answer:" afterStatus
-          headerAnswer = maybe Nothing (\start -> Just (drop (start + 8) afterStatus)) answerStart  -- Up to end of header
-          -- Body: Split comment text and any multi-line answer
-          (textLines, answerLines) = span (not . ("[answer:" `isPrefixOf`)) body
-          text = intercalate "\n" (map trim textLines)
-          bodyAnswer = if null answerLines then Nothing else Just (intercalate "\n" (map trim (tail answerLines)))  -- Skip [answer: line if present
-          finalAnswer = case (headerAnswer, bodyAnswer) of
-                          (Just ha, Just ba) -> Just (ha ++ "\n" ++ ba)  -- Combine if both
-                          (Just ha, Nothing) -> Just ha
-                          (Nothing, Just ba) -> Just ba
-                          _ -> Nothing
-          updated = map (\c -> if cmId c == cid then c { cmText = if null text then cmText c else text, cmStatus = status, cmAnswer = finalAnswer } else c) accCmts
-      in updated
-    parseBlock _ accCmts = accCmts  -- Invalid block, skip
-
-    findSub :: String -> String -> Maybe Int
-    findSub sub str = go 0 str
-      where go _ [] = Nothing
-            go i xs = if sub `isPrefixOf` xs then Just i else go (i+1) (tail xs)
 
 data NavAction = NavNext | NavPrevious | NavOpen
 

--- a/pr-tools.cabal
+++ b/pr-tools.cabal
@@ -50,6 +50,7 @@ library
                   , PRTools.CommentRenderer
                   , PRTools.CommentFormatter
                   , PRTools.Slack
+		  , PRTools.FixParser
   build-depends:    aeson >= 2.2.3 && < 2.3
                   , containers >= 0.6.7 && < 0.7
                   , directory >= 1.3.8 && < 1.4
@@ -179,3 +180,20 @@ executable pr-init
                   , directory >= 1.3.8 && < 1.4
                   , process >= 1.6.19 && < 1.7
   hs-source-dirs:   app
+
+
+test-suite pr-tools-tests
+  type:                exitcode-stdio-1.0
+  main-is:             Spec.hs
+  hs-source-dirs:      test
+  build-depends:
+      base >=4.7 && <5
+    , pr-tools
+    , hspec
+    , hspec-discover
+  build-tool-depends:
+      hspec-discover:hspec-discover
+  other-modules:
+      FixParserSpec
+  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010

--- a/src/PRTools/FixParser.hs
+++ b/src/PRTools/FixParser.hs
@@ -1,0 +1,62 @@
+module PRTools.FixParser
+  ( parseBlock
+  ) where
+
+import Data.List (findIndex, intercalate, isPrefixOf)
+import Data.List.Extra (trim)
+import PRTools.ReviewState (Cmt(..))
+
+-- | Parses a block of text representing a single comment from an edited source file
+-- | during a fix session. It updates a list of existing comments with any changes
+-- | found in the block.
+parseBlock :: [String] -> [Cmt] -> [Cmt]
+parseBlock (header:body) accCmts =
+  let cidStart = length ("-- REVIEW COMMENT BEGIN [" :: String)
+      cidEnd = findIndex (== ']') (drop cidStart header)
+      cid = maybe "" (\end -> take end (drop cidStart header)) cidEnd
+      afterCid = maybe "" (\end -> drop (cidStart + end + 1) header) cidEnd
+      statusStart = findSub "[status:" afterCid
+      afterStatusLabel = maybe afterCid (\start -> drop (start + 8) afterCid) statusStart
+      statusEnd = findIndex (== ']') afterStatusLabel
+      status = maybe "not-solved" (\end -> take end afterStatusLabel) statusEnd
+      afterStatus = maybe afterStatusLabel (\end -> drop (end + 1) afterStatusLabel) statusEnd
+      answerStart = findSub "[answer:" afterStatus
+
+      headerAnswer = case answerStart of
+        Nothing -> Nothing
+        Just start ->
+          let answerWithBracket = drop (start + 8) afterStatus
+              answerEnd = findIndex (== ']') answerWithBracket
+          in Just $ maybe answerWithBracket (\end -> take end answerWithBracket) answerEnd
+
+      (textLines, answerLines) = span (not . ("[answer:" `isPrefixOf`)) body
+      text = intercalate "\n" (map trim textLines)
+      bodyAnswer =
+        if null answerLines
+        then Nothing
+        else Just (intercalate "\n" (map trim (tail answerLines)))  -- Skip the [answer: line itself
+
+      finalAnswer = case (headerAnswer, bodyAnswer) of
+        (Just ha, Just ba) -> Just (ha ++ "\n" ++ ba)
+        (Just ha, Nothing) -> Just ha
+        (Nothing, Just ba) -> Just ba
+        _ -> Nothing
+
+      updated =
+        map
+          (\c ->
+             if cmId c == cid
+             then c { cmText = if null text then cmText c else text
+                    , cmStatus = status
+                    , cmAnswer = finalAnswer
+                    }
+             else c)
+          accCmts
+  in updated
+parseBlock _ accCmts = accCmts
+
+findSub :: String -> String -> Maybe Int
+findSub sub str = go 0 str
+  where
+    go _ [] = Nothing
+    go i xs = if sub `isPrefixOf` xs then Just i else go (i+1) (tail xs)

--- a/test/FixParserSpec.hs
+++ b/test/FixParserSpec.hs
@@ -1,0 +1,19 @@
+module FixParserSpec (spec) where
+
+import Test.Hspec
+import PRTools.ReviewState (Cmt(..))
+import PRTools.FixParser (parseBlock)
+
+spec :: Spec
+spec = do
+  describe "PRTools.FixParser.parseBlock" $ do
+    it "should correctly parse an answer without the trailing square bracket" $ do
+      let initialComment = Cmt "id123" "file.hs" 1 "text" False "not-solved" Nothing ""
+      let comments = [initialComment]
+      -- THIS IS THE CORRECTED LINE:
+      let header = "-- REVIEW COMMENT BEGIN [id123] [status:solved] [answer:My answer is here]]"
+      let block = [header]
+
+      let updatedComments = parseBlock block comments
+      let resultComment = head updatedComments
+      cmAnswer resultComment `shouldBe` Just "My answer is here"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
Fixes an answer parsing bug in `pr-fix` where the trailing `]` was incorrectly included in the answer text.

The parsing logic is refactored into a new testable module (`PRTools.FixParser`) and is now covered by a regression test.

Fixes #40