### PR TITLE
refactor: make pr-track rebase command optional for old commit

### DIFF
--- a/app/pr-track.hs
+++ b/app/pr-track.hs
@@ -22,7 +22,7 @@ data Command =
   | Status { sBranch :: Maybe String }
   | Record { rBranch :: Maybe String, rTip :: Maybe String }
   | List
-  | Rebase { reBranch :: Maybe String, reOldCommit :: String, reNewCommit :: Maybe String }
+  | Rebase { reBranch :: Maybe String, reOldCommit :: Maybe String, reNewCommit :: Maybe String }
   | Debug { dBranch :: Maybe String, dOldCommit :: String, dNewCommit :: Maybe String }
   | Migrate
 
@@ -59,7 +59,7 @@ commandParser = subparser
       <*> optional (strOption (long "tip" <> metavar "TIP" <> help "The tip commit of the PR (default BRANCH)"))
     rebaseParser = Rebase
       <$> optional (strOption (long "branch" <> metavar "BRANCH" <> help "Branch that was rebased (default: current)"))
-      <*> strOption (long "old-commit" <> metavar "HASH" <> help "Commit hash before rebase")
+      <*> optional (strOption (long "old-commit" <> metavar "HASH" <> help "Commit hash before rebase (default: find from approval history)"))
       <*> optional (strOption (long "new-commit" <> metavar "HASH" <> help "Commit hash after rebase (default: current HEAD)"))
     debugParser = Debug
       <$> optional (strOption (long "branch" <> metavar "BRANCH" <> help "Branch to debug (default: current)"))
@@ -240,7 +240,7 @@ main = do
             let boldEnd = if status == "open" || status == "stale" then "\ESC[0m" else ""
             putStrLn $ boldStart ++ b ++ ": " ++ status ++ " (approvals: " ++ show approvalCount ++ ")" ++ boldEnd
             ) sortedByActivity
-    Rebase mbBranch oldCommit mbNewCommit -> do
+    Rebase mbBranch mbOldCommit mbNewCommit -> do
       branch <- case mbBranch of
         Just b -> return b
         Nothing -> fmap trimTrailing (readProcess "git" ["rev-parse", "--abbrev-ref", "HEAD"] "")
@@ -249,7 +249,7 @@ main = do
         Just c -> return c
         Nothing -> fmap trimTrailing (readProcess "git" ["rev-parse", branch] "")
       
-      transferApprovalsAfterRebaseWithBase branch oldCommit newCommit baseB
+      transferApprovalsAfterRebaseWithBase branch mbOldCommit newCommit baseB
     Debug mbBranch oldCommit mbNewCommit -> do
       branch <- case mbBranch of
         Just b -> return b

--- a/src/PRTools/PRState.hs
+++ b/src/PRTools/PRState.hs
@@ -393,17 +393,39 @@ checkValidApprovalsWithBase branch base = do
       return (if flg then x:ys else ys)
 
 -- Transfer approvals after a rebase by updating commit hashes while preserving content hashes
-transferApprovalsAfterRebase :: String -> String -> String -> IO ()
-transferApprovalsAfterRebase branch oldCommit newCommit = do
+transferApprovalsAfterRebase :: String -> Maybe String -> String -> IO ()
+transferApprovalsAfterRebase branch mbOldCommit newCommit = do
   base <- getBaseBranch
-  transferApprovalsAfterRebaseWithBase branch oldCommit newCommit base
+  transferApprovalsAfterRebaseWithBase branch mbOldCommit newCommit base
 
-transferApprovalsAfterRebaseWithBase :: String -> String -> String -> String -> IO ()
-transferApprovalsAfterRebaseWithBase branch oldCommit newCommit base = do
+transferApprovalsAfterRebaseWithBase :: String -> Maybe String -> String -> String -> IO ()
+transferApprovalsAfterRebaseWithBase branch mbOldCommit newCommit base = do
   state <- loadState
   case Map.lookup branch state of
     Nothing -> putStrLn "No PR state found for branch"
     Just pr -> do
+      -- Find old commit from approval history if not provided
+      oldCommit <- case mbOldCommit of
+        Just commit -> return commit
+        Nothing -> do
+          let approvals = approvalHistory pr
+          if null approvals
+            then do
+              putStrLn "No approvals found to transfer from"
+              exitFailure
+            else do
+              -- Use the most recent approval's first commit
+              let latestApproval = last approvals
+              let commits = apCommits latestApproval
+              if null commits
+                then do
+                  putStrLn "No commits found in latest approval"
+                  exitFailure
+                else do
+                  let oldCommit = ciHash (head commits)
+                  putStrLn $ "Using commit from latest approval: " ++ take 7 oldCommit
+                  return oldCommit
+      
       oldContentHash <- generatePatchHash base oldCommit
       newContentHash <- generatePatchHash base newCommit
       


### PR DESCRIPTION
`rebase` command should be able to read the old commit value from the approval history. This PR only rebases the latest approval.