### PR TITLE
Fix/track rebase branch param

### DIFF
--- a/app/pr-track.hs
+++ b/app/pr-track.hs
@@ -58,7 +58,7 @@ commandParser = subparser
       <$> optional (strArgument (metavar "BRANCH" <> help "Branch to record (default: current)"))
       <*> optional (strOption (long "tip" <> metavar "TIP" <> help "The tip commit of the PR (default BRANCH)"))
     rebaseParser = Rebase
-      <$> optional (strOption (long "branch" <> metavar "BRANCH" <> help "Branch that was rebased (default: current)"))
+      <$> optional (strArgument (metavar "BRANCH" <> help "Branch that was rebased (default: current)"))
       <*> optional (strOption (long "old-commit" <> metavar "HASH" <> help "Commit hash before rebase (default: find from approval history)"))
       <*> optional (strOption (long "new-commit" <> metavar "HASH" <> help "Commit hash after rebase (default: current HEAD)"))
     debugParser = Debug

--- a/app/pr-track.hs
+++ b/app/pr-track.hs
@@ -62,7 +62,7 @@ commandParser = subparser
       <*> optional (strOption (long "old-commit" <> metavar "HASH" <> help "Commit hash before rebase (default: find from approval history)"))
       <*> optional (strOption (long "new-commit" <> metavar "HASH" <> help "Commit hash after rebase (default: current HEAD)"))
     debugParser = Debug
-      <$> optional (strOption (long "branch" <> metavar "BRANCH" <> help "Branch to debug (default: current)"))
+      <$> optional (strArgument (metavar "BRANCH" <> help "Branch to debug (default: current)"))
       <*> strOption (long "old-commit" <> metavar "HASH" <> help "Old commit hash")
       <*> optional (strOption (long "new-commit" <> metavar "HASH" <> help "New commit hash (default: current HEAD)"))
 


### PR DESCRIPTION
All commands of `pr-track` should get the branch parameter as a positional argument
