### PR TITLE
feat: add rebase transfer record to approval history

### DIFF
--- a/src/PRTools/PRState.hs
+++ b/src/PRTools/PRState.hs
@@ -448,10 +448,22 @@ transferApprovalsAfterRebaseWithBase branch mbOldCommit newCommit base = do
                 _ -> approval
               ) (approvalHistory pr)
         
-        let updatedPr = pr { approvalHistory = updatedApprovals }
+        -- Create a new approval entry recording the rebase transfer
+        currentTime <- getCurrentTime
+        let timeStr = formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S" currentTime
+        let rebaseTransferApproval = Approval 
+              { apApprover = "system:rebase-transfer"
+              , apTimestamp = timeStr
+              , apCommits = [CommitInfo oldCommit "rebase transfer" Nothing]
+              , apContentHash = Just oldContentHash
+              }
+        
+        let finalApprovals = updatedApprovals ++ [rebaseTransferApproval]
+        let updatedPr = pr { approvalHistory = finalApprovals }
         let newState = Map.insert branch updatedPr state
         saveState newState
         putStrLn $ "Approvals transferred after rebase. Updated " ++ show (length updatedApprovals) ++ " approvals."
+        putStrLn $ "Added rebase transfer record: " ++ take 7 oldCommit ++ " -> " ++ take 7 newCommit
       else
         putStrLn "Content has changed - approvals cannot be transferred automatically"
 


### PR DESCRIPTION
# PR Snapshot for feature/rebase-approval-keeps-original-approval-history

**Author:** Mihai Giurgeanu

## Description

`pr-track rebase` adds a new commit into approval history referencing the
originally approved commit, making it clear this way that the approval was
automatically transferred by a rebase operation.

## Commits

- 88856e9 feat: add rebase transfer record to approval history


## Diff Summary

```
 src/PRTools/PRState.hs | 14 +++++++++++++-
 1 file changed, 13 insertions(+), 1 deletion(-)

```