### PR TITLE
Fix/pr track status commit order

### DIFF
--- a/app/pr-track.hs
+++ b/app/pr-track.hs
@@ -1,5 +1,6 @@
 import Control.Monad (when)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Data.List (head, intercalate, length, notElem, null, (!!), sortBy, nub)
 import Options.Applicative
 import System.Exit (exitFailure, ExitCode(..))
@@ -25,6 +26,17 @@ data Command =
   | Rebase { reBranch :: Maybe String, reOldCommit :: Maybe String, reNewCommit :: Maybe String }
   | Debug { dBranch :: Maybe String, dOldCommit :: String, dNewCommit :: Maybe String }
   | Migrate
+
+-- Build ordered commit list: latest snapshot first, then earlier snapshots (filtering duplicates)
+buildOrderedCommitList :: [PRSnapshot] -> [CommitInfo]
+buildOrderedCommitList [] = []
+buildOrderedCommitList snapshots = go snapshots Set.empty []
+  where
+    go [] _ acc = reverse acc
+    go (snapshot:rest) seen acc = 
+      let newCommits = filter (\ci -> not (Set.member (ciHash ci) seen)) (psCommits snapshot)
+          newSeen = foldl (\s ci -> Set.insert (ciHash ci) s) seen newCommits
+      in go rest newSeen (reverse newCommits ++ acc)
 
 globalParser :: Parser Global
 globalParser = Global
@@ -159,23 +171,17 @@ main = do
               (code, out, _) <- readProcessWithExitCode "git" ["rev-parse", "--verify", branch] ""
               let branch_exists = code == ExitSuccess
               let branch_tip = if branch_exists then trimTrailing out else ""
-              let all_commits = foldl (\m ps -> foldl (\m' ci -> if Map.member (ciHash ci) m' then m' else Map.insert (ciHash ci) (ci, psTimestamp ps) m') m (psCommits ps)) Map.empty (prSnapshots pr)
-              temp_list <- mapM (\(ci, ts) -> do
+              
+              -- Build ordered list: latest snapshot first, then earlier snapshots (no duplicates)
+              let orderedCommits = buildOrderedCommitList (reverse (prSnapshots pr)) -- reverse to get latest first
+              
+              temp_list <- mapM (\ci -> do
                 is_m <- isAncestor (ciHash ci) baseB
                 is_p <- if not branch_exists then return False else isAncestor (ciHash ci) branch_tip
                 let s = if is_m then "merged" else if is_p then "pending" else "removed"
-                -- Use stored timestamp if available, otherwise fall back to git (for legacy commits)
-                commitTimestamp <- case ciTimestamp ci of
-                  Just timestamp -> return timestamp
-                  Nothing -> do
-                    -- Try to get timestamp from git, but handle case where commit might not exist
-                    (code, out, _) <- readProcessWithExitCode "git" ["log", "-1", "--format=%ct", ciHash ci] ""
-                    if code == ExitSuccess
-                      then return (read (trimTrailing out) :: Int)
-                      else return 0  -- Use epoch time as fallback for missing commits
-                return (ci, s, ts, commitTimestamp)
-                ) (Map.elems all_commits)
-              let sorted_statuses = sortBy (\(_,_,_,t1) (_,_,_,t2) -> compare t2 t1) temp_list -- newest first
+                return (ci, s)
+                ) orderedCommits
+              let sorted_statuses = map (\(ci, s) -> (ci, s, "", 0)) temp_list -- dummy timestamp values since we don't need them
               let mergedCount = length [() | (_,s,_,_) <- sorted_statuses, s == "merged"]
               let pendingCount = length [() | (_,s,_,_) <- sorted_statuses, s == "pending"]
               let removedCount = length [() | (_,s,_,_) <- sorted_statuses, s == "removed"]

--- a/app/pr-track.hs
+++ b/app/pr-track.hs
@@ -181,28 +181,27 @@ main = do
                 let s = if is_m then "merged" else if is_p then "pending" else "removed"
                 return (ci, s)
                 ) orderedCommits
-              let sorted_statuses = map (\(ci, s) -> (ci, s, "", 0)) temp_list -- dummy timestamp values since we don't need them
-              let mergedCount = length [() | (_,s,_,_) <- sorted_statuses, s == "merged"]
-              let pendingCount = length [() | (_,s,_,_) <- sorted_statuses, s == "pending"]
-              let removedCount = length [() | (_,s,_,_) <- sorted_statuses, s == "removed"]
-              let total = length sorted_statuses
+              let mergedCount = length [() | (_,s) <- temp_list, s == "merged"]
+              let pendingCount = length [() | (_,s) <- temp_list, s == "pending"]
+              let removedCount = length [() | (_,s) <- temp_list, s == "removed"]
+              let total = length temp_list
               putStrLn $ "Latest snapshot at " ++ psTimestamp (last (prSnapshots pr))
               putStrLn $ "Commit status: " ++ show mergedCount ++ " merged, " ++ show pendingCount ++ " pending, " ++ show removedCount ++ " removed out of " ++ show total
               let latest = last (prSnapshots pr)
               let latest_hashes = map ciHash (psCommits latest)
-              let hash_to_s = Map.fromList [ (ciHash ci, s) | (ci, s, _, _) <- temp_list ]
+              let hash_to_s = Map.fromList [ (ciHash ci, s) | (ci, s) <- temp_list ]
               let all_latest_merged = not (null latest_hashes) && all (\h -> Map.lookup h hash_to_s == Just "merged") latest_hashes
               if all_latest_merged
                 then putStrLn $ "PR is fully merged into " ++ baseB
                 else return ()
               putStrLn "All historical commits:"
-              mapM_ (\(ci, s, _, _) -> do
+              mapM_ (\(ci, s) -> do
                 isReviewed <- checkCommitReviewStatusWithBase branch (ciHash ci) baseB
                 let reviewStatus = if isReviewed then ", reviewed" else ", not reviewed"
                 let boldStart = if s == "merged" || s == "pending" then "\ESC[1m" else ""
                 let boldEnd = if s == "merged" || s == "pending" then "\ESC[0m" else ""
                 putStrLn $ "- " ++ boldStart ++ take 7 (ciHash ci) ++ " " ++ ciMessage ci ++ " (" ++ s ++ reviewStatus ++ ")" ++ boldEnd
-                ) sorted_statuses
+                ) temp_list
     Record mbBranch mbTip -> do
       branch <- case mbBranch of
         Just b -> return b


### PR DESCRIPTION
# PR Snapshot for fix/pr-track-status-commit-order

**Author:** Mihai Giurgeanu

## Description

Show topological commit order in `pr-track status` based on recorded snapshot order. 

## Commits

- 5de9af7 fix: update pr-track to handle simplified commit status list
- 9dcfea8 feat: Implement topological commit ordering in pr-track status


## Diff Summary

```
 app/pr-track.hs | 47 ++++++++++++++++++++++++++---------------------
 1 file changed, 26 insertions(+), 21 deletions(-)

```