### PR TITLE
Fix/rebase is messing up approvals

### DIFF
--- a/app/pr-merge.hs
+++ b/app/pr-merge.hs
@@ -56,18 +56,29 @@ main = do
         hPutStrLn stderr $ "PR " ++ branch ++ " not approved or not tracked"
         exitFailure
         else do
-          -- Check if current content is approved using content hash matching
-          currentTip <- fmap trimTrailing (readProcess "git" ["rev-parse", branch] "")
-          currentContentHash <- generatePatchHash baseB currentTip
-          
-          let approvals = approvalHistory pr
-          let approvedContentHashes = [hash | approval <- approvals, Just hash <- [apContentHash approval]]
-          
-          if currentContentHash `notElem` approvedContentHashes
+          -- Get current content hash from latest snapshot, or compute if missing
+          let snapshots = prSnapshots pr
+          if null snapshots
             then do
-               hPutStrLn stderr $ "PR " ++ branch ++ " has new content since approval. Please request re-approval."
-               exitFailure
+              hPutStrLn stderr $ "PR " ++ branch ++ " has no snapshots"
+              exitFailure
             else do
+              let latestSnapshot = last snapshots
+              currentContentHash <- case psContentHash latestSnapshot of
+                Just hash -> return hash  -- Use stored hash
+                Nothing -> do
+                  -- Fallback: compute content hash on the spot
+                  currentTip <- fmap trimTrailing (readProcess "git" ["rev-parse", branch] "")
+                  generatePatchHash baseB currentTip
+              
+              let approvals = approvalHistory pr
+              let approvedContentHashes = [hash | approval <- approvals, Just hash <- [apContentHash approval]]
+              
+              if currentContentHash `notElem` approvedContentHashes
+                then do
+                   hPutStrLn stderr $ "PR " ++ branch ++ " has new content since approval. Please request re-approval."
+                   exitFailure
+                else do
                commits <- getCommitInfoBetween baseB branch
                callProcess "git" ["checkout", baseB]
                case strategy of

--- a/app/pr-merge.hs
+++ b/app/pr-merge.hs
@@ -20,6 +20,7 @@ import System.IO (IOMode(AppendMode), hPutStrLn, stderr, withFile)
 import System.Process (callProcess, readProcess)
 import PRTools.Config (getBaseBranch, getSlackWebhook, trimTrailing)
 import PRTools.PRState
+import PRTools.ContentHash (generatePatchHash)
 
 data Opts = Opts
   { optBranch :: Maybe String
@@ -55,14 +56,16 @@ main = do
         hPutStrLn stderr $ "PR " ++ branch ++ " not approved or not tracked"
         exitFailure
         else do
-          -- Stale check
+          -- Check if current content is approved using content hash matching
           currentTip <- fmap trimTrailing (readProcess "git" ["rev-parse", branch] "")
-          let latestApproval = last (approvalHistory pr)
-          let approvedHashes = map ciHash (apCommits latestApproval)
+          currentContentHash <- generatePatchHash baseB currentTip
           
-          if currentTip `notElem` approvedHashes
+          let approvals = approvalHistory pr
+          let approvedContentHashes = [hash | approval <- approvals, Just hash <- [apContentHash approval]]
+          
+          if currentContentHash `notElem` approvedContentHashes
             then do
-               hPutStrLn stderr $ "PR " ++ branch ++ " has new commits since approval. Please request re-approval."
+               hPutStrLn stderr $ "PR " ++ branch ++ " has new content since approval. Please request re-approval."
                exitFailure
             else do
                commits <- getCommitInfoBetween baseB branch


### PR DESCRIPTION
# PR Snapshot for fix/rebase-is-messing-up-approvals

**Author:** Mihai Giurgeanu

## Description

Check approval in all approval history lines, not only in the
latest one. Also, check the approval by content hash and not
by commit hash.

`pr-track rebase` now introduces a new approval history line referencing the
old commit, but `pr-merge` was only checking the latest approval. 

## Commits

- 1c152a9 refactor: optimize content hash retrieval in pr-merge
- 0c7f472 refactor: update pr-merge to validate approvals using content hash matching


## Diff Summary

```
 app/pr-merge.hs | 30 ++++++++++++++++++++++--------
 1 file changed, 22 insertions(+), 8 deletions(-)

```